### PR TITLE
Using cmake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 nelua_cache
 build/
+dumps/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "external/SDL"]
+	path = external/SDL
+	url = https://github.com/libsdl-org/SDL.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,12 @@
 [submodule "external/SDL"]
 	path = external/SDL
 	url = https://github.com/libsdl-org/SDL.git
+[submodule "external/SDL_ttf"]
+	path = external/SDL_ttf
+	url = https://github.com/libsdl-org/SDL_ttf.git
+[submodule "external/SDL_image"]
+	path = external/SDL_image
+	url = https://github.com/libsdl-org/SDL_image
+[submodule "external/SDL_mixer"]
+	path = external/SDL_mixer
+	url = https://github.com/libsdl-org/SDL_mixer

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,26 @@
+# Copyright (c) 2021-present André Luiz Alvares
+# Nene is licensed under the Zlib license.
+# Please refer to the LICENSE file for details
+# SPDX-License-Identifier: Zlib
+
+# Set minimum cmake version, this should go until the latest available release,
+# the first version it's still to be decided though, but it shouldn't be older than the one used by SDL's CMakeLists.
+cmake_minimum_required(VERSION 3.15-3.26)
+
+# Set the project name, version and language
+project(
+  nene
+  VERSION 0.4
+  LANGUAGES C
+)
+
+# set the C standard, be sure to review compile_flags.txt file too.
+set(CMAKE_C_STANDARD_REQUIRED 99)
+
+add_library(${PROJECT_NAME} STATIC)
+
+# add the src and external directories on the building procedure
+add_subdirectory(external)
+add_subdirectory(src)
+add_subdirectory(examples/c)
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,13 +14,12 @@ project(
   LANGUAGES C
 )
 
-# set the C standard, be sure to review compile_flags.txt file too.
+# set the C standard, be sure to follow what's written on compile_flags.txt file.
+# NOTE: if you change this, be sure to update the same setting examples/c/CMakeLists.txt
 set(CMAKE_C_STANDARD_REQUIRED 99)
 
-add_library(${PROJECT_NAME} STATIC)
+add_library(libnene STATIC)
 
 # add the src and external directories on the building procedure
 add_subdirectory(external)
 add_subdirectory(src)
-add_subdirectory(examples/c)
-

--- a/README.md
+++ b/README.md
@@ -1,69 +1,68 @@
 # nene
 [![Matrix](https://img.shields.io/matrix/nene-and-friends:matrix.org?label=Matrix%20chat&logo=matrix)](https://matrix.to/#/#nene-and-friends:matrix.org)
 
+`Nene` it's a little game framework built on top of `SDL2` and it's extension libraries (`SDL2_image`, `SDL2_ttf`, `SDL2_mixer`).
 
-Tiny game library built around SDL2 and it's extension libraries (SDL_image, SDL_ttf, SDL_mixer).
+> Eventually Nene will upgrade to `SDL3`
 
-Is a very simple game library for simple games, for now, using any dependency than the SDL2's ones is a
- non-goal.
+## Dependencies
 
-## Installing
-`Nene` is a library and thus, it doesn't require installation, just the files, however, since it uses SDL2 and nelua language,
-you must make both available.
+### Nene library (runtime, used on games)
+These are bundled with `Nene` and thus no download it's required, more information below.
 
-### Dependencies
-These are all `nene` dependencies:
+- SDL2 `2.26.5`
+- SDL2_image `2.6.3`
+- SDL2_ttf `2.20.2`
+- SDL2_mixer `2.6.3`
+ 
+### Building Nene library
+Installed externally, like on Visual Studio Installer or your system package manager.
 
-- [Nelua language](https://nelua.io/)
-- [SDL2 library](https://www.libsdl.org/)
-- [SDL2_image](https://www.libsdl.org/projects/SDL_image/)
-- [SDL2_ttf](https://www.libsdl.org/projects/SDL_ttf/)
-- [SDL2_mixer](https://www.libsdl.org/projects/SDL_mixer/)
+- C compiler (tested: Clang, MSVC, GCC)
+- CMake
+- Git
 
-First, [install Nelua](https://nelua.io/installing/).
 
-Then, install `SDL2` and it's extension libraries, it's generally available on systems's package managers already, for example, in Ubuntu use the following command:
+### Generating Nene bindings
+For now this is only expected to work on Linux, better support for Windows will be written, however
+bindings are already generated on the repository, thus you don't need to generate them unless you change
+`Nene` and/or the generators.
 
-```
-# you may need use "sudo" before "apt-get" to install these packages on Ubuntu:
-$ apt-get install libsdl2-dev libsdl2-mixer-dev libsdl2-ttf-dev libsdl2-image-dev
-```
+- Lua
+- Teal
+- clang-check
+- Bash
 
-For further details and other operating systems, read [SDL2's installing documentation](https://wiki.libsdl.org/Installation).
+To generate bindings:
 
-Note that Nelua compiles to C and, theorically, you can follow any C with SDL2 programming tutorial in order to install SDL2.
-
-Finally, just download `nene` (see below) and use it in your game as a library.
-
-### Download
-You can either download or clone the latest nene or the latest release
-
-You can clone the latest nene using `git clone` command (or you git client, like `GitHub Desktop` or `git-cola`)
-
-```
-git clone https://github.com/Andre-LA/nene.git
+```sh
+$ sh genbindings.sh
 ```
 
-An alternative is downloading the latest release on the [Releases page](https://github.com/Andre-LA/nene/releases), there
-just downloading the source code of the release is the same as clonning, however, it will not be the latest nene release.
+## Building
 
-Whichever method you use, you only need the `nene` subdirectory of this repository in order to use `nene`.
+> **Note**
+> This section it's still being written.
+
+## Usage
+
+> **Note**
+> This section it's still being written.
 
 ## Examples
 Nene doesn't contains a tutorial yet, but you can find some usage examples on the `examples` directory:
 
-- [Camera](examples/camera.nelua)
-- [Pong](examples/pong.nelua)
-- [Rects](examples/rects.nelua)
-- [Render clip](examples/render_clip.nelua)
-- [Sound and music](examples/sound_and_music.nelua)
-- [Sprite animation](examples/sprite_animation.nelua)
-- [Tilemap](examples/tilemap.nelua)
-- [Web](examples/web.nelua)
+- [Camera](examples/nelua/camera.nelua)
+- [Pong](examples/nelua/pong.nelua)
+- [Rects](examples/nelua/rects.nelua)
+- [Render clip](examples/nelua/render_clip.nelua)
+- [Sound and music](examples/nelua/sound_and_music.nelua)
+- [Sprite animation](examples/nelua/sprite_animation.nelua)
+- [Tilemap](examples/nelua/tilemap.nelua)
+- [Web](examples/nelua/web.nelua)
 
+Screenshot with some of the examples above (these shapes are sprites):
 ![image](https://user-images.githubusercontent.com/8538122/127941148-8597cb04-1bac-49cc-9ba1-909f199be996.png)
 
 ## License
 The license of `nene` it's the same as SDL2: zlib license.
-
-This library uses the nelua language and it's standard libraries, licensed under MIT.

--- a/bindgen/ast_reader.tl
+++ b/bindgen/ast_reader.tl
@@ -250,12 +250,14 @@ end
 
 local ast_reader = {}
 
-function ast_reader.read_file(filepath: string, modname: string, first_expected_symbol: string): {Symbol}
-   assert(filepath, "expected 'filepath' argument, got nil")
+function ast_reader.read_file(source_file: string, modname: string, first_expected_symbol: string): {Symbol}
+   assert(source_file, "expected 'source_file' argument, got nil")
    assert(modname, "expected 'modname' argument, got nil")
    assert(not first_expected_symbol or #first_expected_symbol > 0, "expected 'first_expected_symbol' argument, got nil")
 
    first_expected_symbol = first_expected_symbol or modname
+
+   local filepath = string.format('dumps/%s.txt', source_file)
 
    local dumping: string = ''
 

--- a/bindgen/data/animation.tl
+++ b/bindgen/data/animation.tl
@@ -8,7 +8,7 @@ SPDX-License-Identifier: Zlib
 local Node = require 'bindgen.node'
 local ast_reader = require 'bindgen.ast_reader'
 
-local symbols = ast_reader.read_file('build/ast_dumps/animation.txt', 'nene_Animation')
+local symbols = ast_reader.read_file('animation', 'nene_Animation')
 assert(symbols, "no 'symbols' returned")
 
 local enums = ast_reader.get_enums(symbols, 'nene')

--- a/bindgen/data/audio/music.tl
+++ b/bindgen/data/audio/music.tl
@@ -8,7 +8,7 @@ SPDX-License-Identifier: Zlib
 local Node = require 'bindgen.node'
 local ast_reader = require 'bindgen.ast_reader'
 
-local symbols = ast_reader.read_file('build/ast_dumps/audio/music.txt', 'nene_Music')
+local symbols = ast_reader.read_file('audio/music', 'nene_Music')
 assert(symbols, "no 'symbols' returned")
 
 local structs = ast_reader.get_structs(symbols, 'nene')

--- a/bindgen/data/audio/sound.tl
+++ b/bindgen/data/audio/sound.tl
@@ -8,7 +8,7 @@ SPDX-License-Identifier: Zlib
 local Node = require 'bindgen.node'
 local ast_reader = require 'bindgen.ast_reader'
 
-local symbols = ast_reader.read_file('build/ast_dumps/audio/sound.txt', 'nene_Sound')
+local symbols = ast_reader.read_file('audio/sound', 'nene_Sound')
 assert(symbols, "no 'symbols' returned")
 
 local structs = ast_reader.get_structs(symbols, 'nene')

--- a/bindgen/data/collision.tl
+++ b/bindgen/data/collision.tl
@@ -1,14 +1,14 @@
-
-
-
-
-
-
+--[[
+Copyright (c) 2021-present André Luiz Alvares
+Nene is licensed under the Zlib license.
+Please refer to the LICENSE file for details
+SPDX-License-Identifier: Zlib
+]]
 
 local Node = require('bindgen.node')
 local ast_reader = require('bindgen.ast_reader')
 
-local symbols = ast_reader.read_file('build/ast_dumps/collision.txt', 'nene_Collision')
+local symbols = ast_reader.read_file('collision', 'nene_Collision')
 assert(symbols, "no 'symbols' returned")
 
 local structs = ast_reader.get_structs(symbols, 'nene')

--- a/bindgen/data/color.tl
+++ b/bindgen/data/color.tl
@@ -8,7 +8,7 @@ SPDX-License-Identifier: Zlib
 local Node = require 'bindgen.node'
 local ast_reader = require 'bindgen.ast_reader'
 
-local symbols = ast_reader.read_file('build/ast_dumps/color.txt', 'nene_Color')
+local symbols = ast_reader.read_file('color', 'nene_Color')
 assert(symbols, "no 'symbols' returned")
 
 local funcs = ast_reader.get_functions(symbols, 'nene_Color')

--- a/bindgen/data/core.tl
+++ b/bindgen/data/core.tl
@@ -8,7 +8,7 @@ SPDX-License-Identifier: Zlib
 local Node = require 'bindgen.node'
 local ast_reader = require 'bindgen.ast_reader'
 
-local symbols = ast_reader.read_file('build/ast_dumps/core.txt', 'nene_GamepadState')
+local symbols = ast_reader.read_file('core', 'nene_GamepadState')
 assert(symbols, "no 'symbols' returned")
 
 local structs = ast_reader.get_structs(symbols, 'nene')

--- a/bindgen/data/font.tl
+++ b/bindgen/data/font.tl
@@ -8,7 +8,7 @@ SPDX-License-Identifier: Zlib
 local Node = require 'bindgen.node'
 local ast_reader = require 'bindgen.ast_reader'
 
-local symbols = ast_reader.read_file('build/ast_dumps/font.txt', 'nene_Font')
+local symbols = ast_reader.read_file('font', 'nene_Font')
 assert(symbols, "no 'symbols' returned")
 
 local structs = ast_reader.get_structs(symbols, 'nene')

--- a/bindgen/data/intersections.tl
+++ b/bindgen/data/intersections.tl
@@ -9,7 +9,7 @@ local utils = require 'bindgen.utils'
 local Node = require 'bindgen.node'
 local ast_reader = require 'bindgen.ast_reader'
 
-local symbols = ast_reader.read_file('build/ast_dumps/intersections.txt', 'nene_IntersectionRectfWithRectf')
+local symbols = ast_reader.read_file('intersections', 'nene_IntersectionRectfWithRectf')
 assert(symbols, "no 'symbols' returned")
 
 local structs = ast_reader.get_structs(symbols, 'nene')

--- a/bindgen/data/math/grid.tl
+++ b/bindgen/data/math/grid.tl
@@ -8,7 +8,7 @@ SPDX-License-Identifier: Zlib
 local Node = require 'bindgen.node'
 local ast_reader = require 'bindgen.ast_reader'
 
-local symbols = ast_reader.read_file('build/ast_dumps/math/grid.txt', 'nene_Grid')
+local symbols = ast_reader.read_file('math/grid', 'nene_Grid')
 assert(symbols, " no 'symbols' returned")
 
 local structs = ast_reader.get_structs(symbols, 'nene')

--- a/bindgen/data/math/rect.tl
+++ b/bindgen/data/math/rect.tl
@@ -8,7 +8,7 @@ SPDX-License-Identifier: Zlib
 local Node = require 'bindgen.node'
 local ast_reader = require 'bindgen.ast_reader'
 
-local symbols = ast_reader.read_file('build/ast_dumps/math/rect.txt', 'nene_Rect')
+local symbols = ast_reader.read_file('math/rect', 'nene_Rect')
 assert(symbols, "no 'symbols' returned")
 
 local structs = ast_reader.get_structs(symbols, 'nene')

--- a/bindgen/data/math/rectf.tl
+++ b/bindgen/data/math/rectf.tl
@@ -8,7 +8,7 @@ SPDX-License-Identifier: Zlib
 local Node = require 'bindgen.node'
 local ast_reader = require 'bindgen.ast_reader'
 
-local symbols = ast_reader.read_file('build/ast_dumps/math/rectf.txt', 'nene_Rectf')
+local symbols = ast_reader.read_file('math/rectf', 'nene_Rectf')
 assert(symbols, "no 'symbols' returned")
 
 local structs = ast_reader.get_structs(symbols, 'nene')

--- a/bindgen/data/math/segment.tl
+++ b/bindgen/data/math/segment.tl
@@ -8,7 +8,7 @@ SPDX-License-Identifier: Zlib
 local Node = require 'bindgen.node'
 local ast_reader = require 'bindgen.ast_reader'
 
-local symbols = ast_reader.read_file('build/ast_dumps/math/segment.txt', 'nene_Segment')
+local symbols = ast_reader.read_file('math/segment', 'nene_Segment')
 assert(symbols, "no 'symbols' returned")
 
 local structs = ast_reader.get_structs(symbols, 'nene')

--- a/bindgen/data/math/shape.tl
+++ b/bindgen/data/math/shape.tl
@@ -8,7 +8,7 @@ SPDX-License-Identifier: Zlib
 local Node = require 'bindgen.node'
 local ast_reader = require 'bindgen.ast_reader'
 
-local symbols = ast_reader.read_file('build/ast_dumps/math/shape.txt', 'nene_Shape', 'nene_ShapeQuadrilateral')
+local symbols = ast_reader.read_file('math/shape', 'nene_Shape', 'nene_ShapeQuadrilateral')
 assert(symbols, "no 'symbols' returned")
 
 local structs = ast_reader.get_structs(symbols, 'nene')

--- a/bindgen/data/math/vec2.tl
+++ b/bindgen/data/math/vec2.tl
@@ -8,7 +8,7 @@ SPDX-License-Identifier: Zlib
 local Node = require 'bindgen.node'
 local ast_reader = require 'bindgen.ast_reader'
 
-local symbols = ast_reader.read_file('build/ast_dumps/math/vec2.txt', 'nene_Vec2')
+local symbols = ast_reader.read_file('math/vec2', 'nene_Vec2')
 assert(symbols, "no 'symbols' returned")
 
 local structs = ast_reader.get_structs(symbols, 'nene')

--- a/bindgen/data/math/vec2i.tl
+++ b/bindgen/data/math/vec2i.tl
@@ -8,7 +8,7 @@ SPDX-License-Identifier: Zlib
 local Node = require 'bindgen.node'
 local ast_reader = require 'bindgen.ast_reader'
 
-local symbols = ast_reader.read_file('build/ast_dumps/math/vec2i.txt', 'nene_Vec2i')
+local symbols = ast_reader.read_file('math/vec2i', 'nene_Vec2i')
 assert(symbols, "no 'symbols' returned")
 
 local structs = ast_reader.get_structs(symbols, 'nene')

--- a/bindgen/data/texture.tl
+++ b/bindgen/data/texture.tl
@@ -8,7 +8,7 @@ SPDX-License-Identifier: Zlib
 local Node = require 'bindgen.node'
 local ast_reader = require 'bindgen.ast_reader'
 
-local symbols = ast_reader.read_file('build/ast_dumps/texture.txt', 'nene_Texture')
+local symbols = ast_reader.read_file('texture', 'nene_Texture')
 assert(symbols, "no 'symbols' returned")
 
 local structs = ast_reader.get_structs(symbols, 'nene')

--- a/bindgen/data/texture_atlas.tl
+++ b/bindgen/data/texture_atlas.tl
@@ -8,7 +8,7 @@ SPDX-License-Identifier: Zlib
 local Node = require 'bindgen.node'
 local ast_reader = require 'bindgen.ast_reader'
 
-local symbols = ast_reader.read_file('build/ast_dumps/texture_atlas.txt', 'nene_TextureAtlas')
+local symbols = ast_reader.read_file('texture_atlas', 'nene_TextureAtlas')
 assert(symbols, "no 'symbols' returned")
 
 local structs = ast_reader.get_structs(symbols, 'nene')

--- a/bindgen/data/tilemap.tl
+++ b/bindgen/data/tilemap.tl
@@ -9,7 +9,7 @@ local utils = require 'bindgen.utils'
 local Node = require 'bindgen.node'
 local ast_reader = require 'bindgen.ast_reader'
 
-local symbols = ast_reader.read_file('build/ast_dumps/tilemap.txt', 'nene_Tilemap')
+local symbols = ast_reader.read_file('tilemap', 'nene_Tilemap')
 assert(symbols, "no 'symbols' returned")
 
 local structs = ast_reader.get_structs(symbols, 'nene')

--- a/compile_flags.txt
+++ b/compile_flags.txt
@@ -3,3 +3,7 @@
 -Wpedantic
 -std=c99
 -I./include/
+-I./external/SDL/include
+-I./external/SDL_mixer/include
+-I./external/SDL_image
+-I./external/SDL_ttf

--- a/examples/c/CMakeLists.txt
+++ b/examples/c/CMakeLists.txt
@@ -3,7 +3,5 @@
 # Please refer to the LICENSE file for details
 # SPDX-License-Identifier: Zlib
 
-add_executable(nene_c_collisions collisions.c)
-
-target_link_libraries(nene_c_collisions nene)
-
+add_executable(nene_c_collisions WIN32 collisions.c)
+target_link_libraries(nene_c_collisions PRIVATE nene)

--- a/examples/c/CMakeLists.txt
+++ b/examples/c/CMakeLists.txt
@@ -1,0 +1,9 @@
+# Copyright (c) 2021-present André Luiz Alvares
+# Nene is licensed under the Zlib license.
+# Please refer to the LICENSE file for details
+# SPDX-License-Identifier: Zlib
+
+add_executable(nene_c_collisions collisions.c)
+
+target_link_libraries(nene_c_collisions nene)
+

--- a/examples/c/CMakeLists.txt
+++ b/examples/c/CMakeLists.txt
@@ -3,5 +3,16 @@
 # Please refer to the LICENSE file for details
 # SPDX-License-Identifier: Zlib
 
+# Set the project name, version and language
+project(
+  nene_examples
+  VERSION 0.1
+  LANGUAGES C
+)
+
+# set the C standard, be sure to follow what's written on compile_flags.txt file.
+set(CMAKE_C_STANDARD_REQUIRED 99)
+
+# finally, the examples
 add_executable(nene_c_collisions WIN32 collisions.c)
-target_link_libraries(nene_c_collisions PRIVATE nene)
+target_link_libraries(nene_c_collisions PRIVATE libnene)

--- a/examples/c/collisions.c
+++ b/examples/c/collisions.c
@@ -5,6 +5,7 @@ Please refer to the LICENSE file for details
 SPDX-License-Identifier: Zlib
 */
 
+#include <stdlib.h>
 #include "nene/core.h"
 #include "nene/collision.h"
 
@@ -17,8 +18,9 @@ int main(void) {
   // nene_Rectf rect  = { .size = { .x = 40, .y = 260 } };
   nene_Rectf rect  = { .size = { .x = 4, .y = 26 } };
 
-  #define SEGMENTS_LEN 4
-  nene_Segment segments[SEGMENTS_LEN] = {
+  #define SEGMENTS_COUNT 4
+
+  nene_Segment segments[SEGMENTS_COUNT] = {
     { { -500, 200 }, { -400, 150 } },
     { { -300, -130 }, { -120, -100 } },
     { { -40, -030 }, { 220, 200 } },
@@ -48,7 +50,7 @@ int main(void) {
     rect.pos = nene_Vec2_add(rect.pos, delta);
 
     if (!nene_Core_is_scancode_held(SDL_SCANCODE_SPACE)) {
-      for (int i = 0; i < SEGMENTS_LEN; ++i) {
+      for (int i = 0; i < SEGMENTS_COUNT; ++i) {
         nene_Collision collision = nene_Collision_rectf_with_segment(rect, segments[i], delta);
         if (collision.collided) {
           rect.pos = nene_Vec2_add(rect.pos, collision.delta);
@@ -60,16 +62,15 @@ int main(void) {
 
     nene_Core_render_draw_rect(nene_Rectf_to_rect(rect), true, color, true);
 
-    for (int i = 0; i < SEGMENTS_LEN; ++i) {
+    for (int i = 0; i < SEGMENTS_COUNT; ++i) {
       nene_Core_render_draw_line(segments[i].origin, segments[i].ending, nene_Color_black, true);
     }
 
     nene_Core_render_present();
-    
-    #undef SEGMENTS_LEN
-    
   } while (!nene_Core_should_quit());
 
+  #undef SEGMENTS_COUNT
+  
   nene_Core_terminate();
   return EXIT_SUCCESS;
 }

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -5,6 +5,15 @@
 
 # This cmake file add the "external_libs" library target, with all external modules (that is, SDL libraries)
 
+# setup options, in summary, use SDL's vendored dependencies instead of relying on package managers and
+# do not "install" SDL.
+set(SDL2IMAGE_VENDORED ON CACHE BOOL "")
+set(SDL2MIXER_VENDORED ON CACHE BOOL "")
+set(SDL2TTF_VENDORED ON CACHE BOOL "")
+set(SDL2TTF_INSTALL OFF CACHE BOOL "")
+set(SDL2MIXER_INSTALL OFF CACHE BOOL "")
+set(SDL2IMAGE_INSTALL OFF CACHE BOOL "")
+
 # Adds the SDL subdirectories, which are git sub-modules,
 # be sure to clone nene with "recurse-submodules" flag, otherwise the SDL
 # libraries will not be clonned with nene.
@@ -19,11 +28,11 @@ add_library(external_libs INTERFACE)
 # adding linking to the SDL libraries to the project build.
 # context: https://wiki.libsdl.org/SDL2/README/cmake
 if(TARGET SDL2::SDL2main)
-  target_link_libraries(${PROJECT_NAME} INTERFACE SDL2::SDL2main)
+  target_link_libraries(libnene INTERFACE SDL2::SDL2main)
 endif()
 
-target_link_libraries(${PROJECT_NAME} INTERFACE SDL2::SDL2)
-target_link_libraries(${PROJECT_NAME} INTERFACE SDL2_image::SDL2_image)
-target_link_libraries(${PROJECT_NAME} INTERFACE SDL2_mixer::SDL2_mixer)
-target_link_libraries(${PROJECT_NAME} INTERFACE SDL2_ttf::SDL2_ttf)
+target_link_libraries(libnene INTERFACE SDL2::SDL2)
+target_link_libraries(libnene INTERFACE SDL2_image::SDL2_image)
+target_link_libraries(libnene INTERFACE SDL2_mixer::SDL2_mixer)
+target_link_libraries(libnene INTERFACE SDL2_ttf::SDL2_ttf)
 

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -1,0 +1,24 @@
+# Copyright (c) 2021-present André Luiz Alvares
+# Nene is licensed under the Zlib license.
+# Please refer to the LICENSE file for details
+# SPDX-License-Identifier: Zlib
+
+# This cmake file add the "external_libs" library target, with all external modules (that is, SDL libraries)
+
+# Adds the SDL subdirectories, which are git sub-modules,
+# be sure to clone nene with "recurse-submodules" flag, otherwise the SDL
+# libraries will not be clonned with nene.
+add_subdirectory(SDL)
+add_subdirectory(SDL_image)
+add_subdirectory(SDL_mixer)
+add_subdirectory(SDL_ttf)
+
+# creating the "external_libs" library target
+add_library(external_libs INTERFACE)
+
+# adding linking to the SDL libraries to the project build.
+target_link_libraries(${PROJECT_NAME} INTERFACE SDL2::SDL2)
+target_link_libraries(${PROJECT_NAME} INTERFACE SDL2_image::SDL2_image)
+target_link_libraries(${PROJECT_NAME} INTERFACE SDL2_mixer::SDL2_mixer)
+target_link_libraries(${PROJECT_NAME} INTERFACE SDL2_ttf::SDL2_ttf)
+

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -17,6 +17,11 @@ add_subdirectory(SDL_ttf)
 add_library(external_libs INTERFACE)
 
 # adding linking to the SDL libraries to the project build.
+# context: https://wiki.libsdl.org/SDL2/README/cmake
+if(TARGET SDL2::SDL2main)
+  target_link_libraries(${PROJECT_NAME} INTERFACE SDL2::SDL2main)
+endif()
+
 target_link_libraries(${PROJECT_NAME} INTERFACE SDL2::SDL2)
 target_link_libraries(${PROJECT_NAME} INTERFACE SDL2_image::SDL2_image)
 target_link_libraries(${PROJECT_NAME} INTERFACE SDL2_mixer::SDL2_mixer)

--- a/genbindings.sh
+++ b/genbindings.sh
@@ -8,73 +8,25 @@
 # tl: the Teal language compiler.
 # You also will need to install a Lua runtime on your system (required by Teal).
 
-# usage: just use the command "$ sh build.sh"
-#
-# you can also change the C compiler or object archiver by
-# passing arguments, like: "$ sh build.sh emcc emar"
-#
-# Note: currently only clang with llvm-ar, and emcc with emar are tested.
+# usage: just use the command "$ sh genbindings.sh"
 
 # utils
-build_log() {
-  echo "nene build log: $1"
+bindgen_log() {
+  echo "nene bindgen log: $1"
 }
 
-# variables
-CC=clang
-AR=llvm-ar
-
-if [ $# -gt 0 ] # C compiler passed
-then
-CC=$1
-fi
-
-if [ $# -gt 1 ] # Object archiver passed
-then
-AR=$2
-fi
-
-# log configuration
-build_log "C compiler: $CC"
-build_log "Object achiver: $AR"
-
-# setup flags
-
-## warning flags
-WFLAGS="-Wall -Wextra -Wpedantic"
-
-## C standard flag
-CSTD="-std=c99"
-
-## include flags
-IFLAGS="-I./include/"
-
-## source files
-SOURCES="src/*.c src/math/*.c src/audio/*.c"
-
 # clear previous build
-build_log "clear previous build"
+bindgen_log "clear previous build"
 
-rm -rf build/
-mkdir build/
-mkdir build/ast_dumps
-mkdir build/ast_dumps/math
-mkdir build/ast_dumps/audio
-
-# compile sources
-build_log "creating object files"
-
-$CC -c $WFLAGS $CSTD $IFLAGS $SOURCES
-mv *.o build/
-
-# archive objects for static linking
-build_log "archiving object files"
-$AR -rcs build/libnene.a build/*.o
+rm -rf dumps/
+mkdir dumps/
+mkdir dumps/math
+mkdir dumps/audio
 
 # dump AST
-build_log "dumping ASTs"
+bindgen_log "dumping ASTs"
 dump_ast() {
-  clang-check include/nene/$1.h -ast-dump -ast-dump-filter=$2 --extra-arg="-fno-color-diagnostics" > build/ast_dumps/$3.txt 
+  clang-check include/nene/$1.h -ast-dump -ast-dump-filter=$2 --extra-arg="-fno-color-diagnostics" > dumps/$3.txt 
 }
 
 dump_ast "core" "nene" "core"
@@ -97,8 +49,11 @@ dump_ast "tilemap" "nene_Tilemap" "tilemap"
 dump_ast "color" "nene_Color" "color"
 
 # generate bindings
-build_log "generating bindings"
-build_log "generating nelua bindings"
+bindgen_log "generating bindings"
+bindgen_log "generating nelua bindings"
 tl run bindgen/generate_nelua.tl
 
-build_log "done"
+# bindgen_log "generating carp bindings"
+# $LUA bindgen/generate_carp.lua
+
+bindgen_log "done"

--- a/include/nene/audio/music.h
+++ b/include/nene/audio/music.h
@@ -10,7 +10,7 @@ SPDX-License-Identifier: Zlib
 
 #include <stdbool.h>
 #include <stdint.h>
-#include <SDL2/SDL_mixer.h>
+#include <SDL_mixer.h>
 
 typedef struct nene_Music {
   Mix_Music *raw;

--- a/include/nene/audio/sound.h
+++ b/include/nene/audio/sound.h
@@ -10,7 +10,7 @@ SPDX-License-Identifier: Zlib
 
 #include <stdint.h>
 #include <stdbool.h>
-#include <SDL2/SDL_mixer.h>
+#include <SDL_mixer.h>
 
 typedef struct nene_Sound {
   Mix_Chunk *raw;

--- a/include/nene/color.h
+++ b/include/nene/color.h
@@ -9,7 +9,7 @@ SPDX-License-Identifier: Zlib
 #define NENE_COLOR_H
 
 #include <stdbool.h>
-#include <SDL2/SDL.h>
+#include <SDL.h>
 
 /// Alias to SDL_color
 typedef SDL_Color nene_Color;

--- a/include/nene/core.h
+++ b/include/nene/core.h
@@ -9,7 +9,7 @@ SPDX-License-Identifier: Zlib
 #define NENE_CORE_H
 
 #include <stdbool.h>
-#include <SDL2/SDL.h>
+#include <SDL.h>
 #include "nene/config.h"
 #include "nene/math/vec2.h"
 #include "nene/math/vec2i.h"

--- a/include/nene/font.h
+++ b/include/nene/font.h
@@ -10,7 +10,7 @@ SPDX-License-Identifier: Zlib
 
 #include <stdint.h>
 #include <stdbool.h>
-#include <SDL2/SDL_ttf.h>
+#include <SDL_ttf.h>
 #include "nene/math/vec2i.h"
 #include "nene/texture.h"
 #include "nene/color.h"

--- a/include/nene/math/rect.h
+++ b/include/nene/math/rect.h
@@ -9,7 +9,7 @@ SPDX-License-Identifier: Zlib
 #define NENE_RECT_H
 
 #include <stdbool.h>
-#include <SDL2/SDL.h>
+#include <SDL.h>
 
 #include "nene/math/vec2i.h"
 

--- a/include/nene/math/rectf.h
+++ b/include/nene/math/rectf.h
@@ -9,7 +9,7 @@ SPDX-License-Identifier: Zlib
 #define NENE_RECTF_H
 
 #include <stdbool.h>
-#include <SDL2/SDL.h>
+#include <SDL.h>
 
 #include "nene/math/vec2.h"
 #include "nene/math/rect.h"

--- a/include/nene/texture.h
+++ b/include/nene/texture.h
@@ -10,7 +10,7 @@ SPDX-License-Identifier: Zlib
 
 #include <stdint.h>
 #include <stdbool.h>
-#include <SDL2/SDL.h>
+#include <SDL.h>
 
 #include "nene/math/vec2.h"
 #include "nene/math/rect.h"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -38,8 +38,7 @@ target_link_libraries(${PROJECT_NAME} PUBLIC external_libs)
 
 # add linking to libm if necessary
 # context: https://cliutils.gitlab.io/modern-cmake/chapters/features/small.html#little-libraries
-
-find_library(LIB_MATH, m)
-if (${LIB_MATH})
-  target_link_libraries(${PROJECT_NAME} PUBLIC m)
+find_library(LIB_MATH m)
+if (LIB_MATH)
+  target_link_libraries(${PROJECT_NAME} PUBLIC ${LIB_MATH})
 endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -35,4 +35,11 @@ target_include_directories(${PROJECT_NAME} PUBLIC ${PROJECT_SOURCE_DIR}/external
 
 # add linking to the external dependencies (SDL libraries) to the target
 target_link_libraries(${PROJECT_NAME} PUBLIC external_libs)
-target_link_libraries(${PROJECT_NAME} PUBLIC m)
+
+# add linking to libm if necessary
+# context: https://cliutils.gitlab.io/modern-cmake/chapters/features/small.html#little-libraries
+
+find_library(LIB_MATH, m)
+if (${LIB_MATH})
+  target_link_libraries(${PROJECT_NAME} PUBLIC m)
+endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,7 +3,7 @@
 # Please refer to the LICENSE file for details
 # SPDX-License-Identifier: Zlib
 
-target_sources(${PROJECT_NAME} PUBLIC
+target_sources(libnene PUBLIC
   core.c
   texture.c
   font.c
@@ -25,20 +25,20 @@ target_sources(${PROJECT_NAME} PUBLIC
 )
 
 # # add the nene include directory
-target_include_directories(${PROJECT_NAME} PUBLIC ${PROJECT_SOURCE_DIR}/include)
+target_include_directories(libnene PUBLIC ${PROJECT_SOURCE_DIR}/include)
 
 # # add the sdl include directories (NOTE: remove these once the (game) usage of SDL get's unnecessary)
-target_include_directories(${PROJECT_NAME} PUBLIC ${PROJECT_SOURCE_DIR}/external/SDL/include)
-target_include_directories(${PROJECT_NAME} PUBLIC ${PROJECT_SOURCE_DIR}/external/SDL_mixer/include)
-target_include_directories(${PROJECT_NAME} PUBLIC ${PROJECT_SOURCE_DIR}/external/SDL_image)
-target_include_directories(${PROJECT_NAME} PUBLIC ${PROJECT_SOURCE_DIR}/external/SDL_ttf)
+target_include_directories(libnene PUBLIC ${PROJECT_SOURCE_DIR}/external/SDL/include)
+target_include_directories(libnene PUBLIC ${PROJECT_SOURCE_DIR}/external/SDL_mixer/include)
+target_include_directories(libnene PUBLIC ${PROJECT_SOURCE_DIR}/external/SDL_image)
+target_include_directories(libnene PUBLIC ${PROJECT_SOURCE_DIR}/external/SDL_ttf)
 
 # add linking to the external dependencies (SDL libraries) to the target
-target_link_libraries(${PROJECT_NAME} PUBLIC external_libs)
+target_link_libraries(libnene PUBLIC external_libs)
 
 # add linking to libm if necessary
 # context: https://cliutils.gitlab.io/modern-cmake/chapters/features/small.html#little-libraries
 find_library(LIB_MATH m)
 if (LIB_MATH)
-  target_link_libraries(${PROJECT_NAME} PUBLIC ${LIB_MATH})
+  target_link_libraries(libnene PUBLIC ${LIB_MATH})
 endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,38 @@
+# Copyright (c) 2021-present André Luiz Alvares
+# Nene is licensed under the Zlib license.
+# Please refer to the LICENSE file for details
+# SPDX-License-Identifier: Zlib
+
+target_sources(${PROJECT_NAME} PUBLIC
+  core.c
+  texture.c
+  font.c
+  texture_atlas.c
+  audio/music.c
+  audio/sound.c
+  math/vec2i.c
+  math/vec2.c
+  math/rect.c
+  math/rectf.c
+  math/grid.c
+  math/segment.c
+  math/shape.c
+  intersections.c
+  collision.c
+  animation.c
+  tilemap.c
+  color.c
+)
+
+# # add the nene include directory
+target_include_directories(${PROJECT_NAME} PUBLIC ${PROJECT_SOURCE_DIR}/include)
+
+# # add the sdl include directories (NOTE: remove these once the (game) usage of SDL get's unnecessary)
+target_include_directories(${PROJECT_NAME} PUBLIC ${PROJECT_SOURCE_DIR}/external/SDL/include)
+target_include_directories(${PROJECT_NAME} PUBLIC ${PROJECT_SOURCE_DIR}/external/SDL_mixer/include)
+target_include_directories(${PROJECT_NAME} PUBLIC ${PROJECT_SOURCE_DIR}/external/SDL_image)
+target_include_directories(${PROJECT_NAME} PUBLIC ${PROJECT_SOURCE_DIR}/external/SDL_ttf)
+
+# add linking to the external dependencies (SDL libraries) to the target
+target_link_libraries(${PROJECT_NAME} PUBLIC external_libs)
+target_link_libraries(${PROJECT_NAME} PUBLIC m)

--- a/src/audio/music.c
+++ b/src/audio/music.c
@@ -6,7 +6,7 @@ SPDX-License-Identifier: Zlib
 */
 
 #include "nene/audio/music.h"
-#include "SDL2/SDL.h"
+#include <SDL.h>
 
 Mix_Music *nene_Music_get_raw(nene_Music music) {
   SDL_assert(music.raw != NULL);

--- a/src/audio/sound.c
+++ b/src/audio/sound.c
@@ -6,7 +6,7 @@ SPDX-License-Identifier: Zlib
 */
 
 #include "nene/audio/sound.h"
-#include <SDL2/SDL.h>
+#include <SDL.h>
 
 Mix_Chunk *nene_Sound_get_raw(nene_Sound sound) {
   SDL_assert(sound.raw != NULL);

--- a/src/core.c
+++ b/src/core.c
@@ -5,11 +5,11 @@ Please refer to the LICENSE file for details
 SPDX-License-Identifier: Zlib
 */
 
-#include <SDL2/SDL.h>
-#include <SDL2/SDL_events.h>
-#include <SDL2/SDL_image.h>
-#include <SDL2/SDL_ttf.h>
-#include <SDL2/SDL_mixer.h>
+#include <math.h>
+#include <SDL_events.h>
+#include <SDL_image.h>
+#include <SDL_ttf.h>
+#include <SDL_mixer.h>
 #include "nene/core.h"
 #include <stdio.h>
 

--- a/src/font.c
+++ b/src/font.c
@@ -5,7 +5,7 @@ Please refer to the LICENSE file for details
 SPDX-License-Identifier: Zlib
 */
 
-#include <SDL2/SDL.h>
+#include <SDL.h>
 #include "nene/font.h"
 #include "nene/core.h"
 

--- a/src/texture.c
+++ b/src/texture.c
@@ -5,8 +5,8 @@ Please refer to the LICENSE file for details
 SPDX-License-Identifier: Zlib
 */
 
-#include <SDL2/SDL_image.h>
-#include <SDL2/SDL_render.h>
+#include <SDL_image.h>
+#include <SDL_render.h>
 #include "nene/texture.h"
 #include "nene/core.h"
 


### PR DESCRIPTION
This PR closes #33 

Building is now done through CMake, tested on Fedora Linux 38 and Windows 11 (VS 2022).

Dependencies (that is, all SDL2 libraries and it's respective dependencies) are bundled on `external` directory as git sub-modules, using `git clone` with `--recurse-submodules` flag will download all these dependencies, thus there's no need to install any dependencies using package managers.

Tasks:
- [x] Use CMake for building, with the same commands and steps
- [x] Rename `build.sh` to `genbindings.sh`
- [x] Edit README with build instructions and updated information (done but incomplete, finish this later)
- [x] ~~Bundle and compile Lua locally just as SDL2~~ (delay to another PR)
- [x] ~~Same for Teal~~ (delay to another PR)