### PR TITLE
Improve cmake support, with installation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,21 +4,16 @@
 # SPDX-License-Identifier: Zlib
 
 # Set minimum cmake version, this should go until the latest available release,
-# the first version it's still to be decided though, but it shouldn't be older than the one used by SDL's CMakeLists.
-cmake_minimum_required(VERSION 3.15-3.26)
+# NOTE: if version interval it's changed, be sure to also update the examples/c/CMakeLists.txt file
+cmake_minimum_required(VERSION 3.23-3.26)
 
 # Set the project name, version and language
 project(
   nene
   VERSION 0.4
+  DESCRIPTION "Game framework on top of SDL aimed for multiple programming languages"
   LANGUAGES C
 )
-
-# set the C standard, be sure to follow what's written on compile_flags.txt file.
-# NOTE: if you change this, be sure to update the same setting examples/c/CMakeLists.txt
-set(CMAKE_C_STANDARD_REQUIRED 99)
-
-add_library(nene STATIC)
 
 # add the src and external directories on the building procedure
 add_subdirectory(external)
@@ -26,3 +21,12 @@ add_subdirectory(src)
 
 # also add examples directory
 add_subdirectory(examples/c)
+
+# nene installation
+install(TARGETS nene external_libs
+  LIBRARY DESTINATION lib
+  ARCHIVE DESTINATION lib
+  RUNTIME DESTINATION bin
+  INCLUDES DESTINATION include
+  FILE_SET HEADERS
+)

--- a/examples/c/CMakeLists.txt
+++ b/examples/c/CMakeLists.txt
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Zlib
 
 # This version should match the interval of nene's root CMakeLists.txt
-cmake_minimum_required(VERSION 3.15-3.26)
+cmake_minimum_required(VERSION 3.23-3.26)
 
 # Set the project name, version and language
 project(
@@ -13,9 +13,14 @@ project(
   LANGUAGES C
 )
 
-# set the C standard, be sure to follow what's written on compile_flags.txt file.
-set(CMAKE_C_STANDARD_REQUIRED 99)
-
 # finally, the examples
 add_executable(collisions WIN32 collisions.c)
 target_link_libraries(collisions PRIVATE nene)
+
+# set the C standard properties, 
+# be sure to follow the same standard of nene (see the src/CMakeLists.txt file)
+set_target_properties(collisions PROPERTIES
+  C_STANDARD 99
+  C_STANDARD_REQUIRED YES
+  C_EXTENSIONS NO
+)

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -10,9 +10,14 @@
 set(SDL2IMAGE_VENDORED ON CACHE BOOL "")
 set(SDL2MIXER_VENDORED ON CACHE BOOL "")
 set(SDL2TTF_VENDORED ON CACHE BOOL "")
-set(SDL2TTF_INSTALL OFF CACHE BOOL "")
-set(SDL2MIXER_INSTALL OFF CACHE BOOL "")
-set(SDL2IMAGE_INSTALL OFF CACHE BOOL "")
+set(SDL2_DISABLE_INSTALL OFF CACHE BOOL "")
+
+set(SDL2IMAGE_SAMPLES OFF CACHE BOOL "")
+set(SDL2TTF_SAMPLES OFF CACHE BOOL "")
+set(SDL2MIXER_SAMPLES OFF CACHE BOOL "")
+
+set(SDL2IMAGE_TESTS OFF CACHE BOOL "")
+set(SDL_TEST OFF CACHE BOOL "")
 
 # Adds the SDL subdirectories, which are git sub-modules,
 # be sure to clone nene with "recurse-submodules" flag, otherwise the SDL
@@ -28,11 +33,10 @@ add_library(external_libs INTERFACE)
 # adding linking to the SDL libraries to the project build.
 # context: https://wiki.libsdl.org/SDL2/README/cmake
 if(TARGET SDL2::SDL2main)
-  target_link_libraries(nene INTERFACE SDL2::SDL2main)
+  target_link_libraries(external_libs INTERFACE SDL2::SDL2main)
 endif()
 
-target_link_libraries(nene INTERFACE SDL2::SDL2)
-target_link_libraries(nene INTERFACE SDL2_image::SDL2_image)
-target_link_libraries(nene INTERFACE SDL2_mixer::SDL2_mixer)
-target_link_libraries(nene INTERFACE SDL2_ttf::SDL2_ttf)
-
+target_link_libraries(external_libs INTERFACE SDL2::SDL2)
+target_link_libraries(external_libs INTERFACE SDL2_image::SDL2_image)
+target_link_libraries(external_libs INTERFACE SDL2_mixer::SDL2_mixer)
+target_link_libraries(external_libs INTERFACE SDL2_ttf::SDL2_ttf)

--- a/include/nene/audio/music.h
+++ b/include/nene/audio/music.h
@@ -10,7 +10,7 @@ SPDX-License-Identifier: Zlib
 
 #include <stdbool.h>
 #include <stdint.h>
-#include <SDL_mixer.h>
+#include "SDL_mixer.h"
 
 typedef struct nene_Music {
   Mix_Music *raw;

--- a/include/nene/audio/sound.h
+++ b/include/nene/audio/sound.h
@@ -10,7 +10,7 @@ SPDX-License-Identifier: Zlib
 
 #include <stdint.h>
 #include <stdbool.h>
-#include <SDL_mixer.h>
+#include "SDL_mixer.h"
 
 typedef struct nene_Sound {
   Mix_Chunk *raw;

--- a/include/nene/color.h
+++ b/include/nene/color.h
@@ -9,7 +9,7 @@ SPDX-License-Identifier: Zlib
 #define NENE_COLOR_H
 
 #include <stdbool.h>
-#include <SDL.h>
+#include "SDL.h"
 
 /// Alias to SDL_color
 typedef SDL_Color nene_Color;

--- a/include/nene/core.h
+++ b/include/nene/core.h
@@ -9,7 +9,7 @@ SPDX-License-Identifier: Zlib
 #define NENE_CORE_H
 
 #include <stdbool.h>
-#include <SDL.h>
+#include "SDL.h"
 #include "nene/config.h"
 #include "nene/math/vec2.h"
 #include "nene/math/vec2i.h"

--- a/include/nene/font.h
+++ b/include/nene/font.h
@@ -10,7 +10,7 @@ SPDX-License-Identifier: Zlib
 
 #include <stdint.h>
 #include <stdbool.h>
-#include <SDL_ttf.h>
+#include "SDL_ttf.h"
 #include "nene/math/vec2i.h"
 #include "nene/texture.h"
 #include "nene/color.h"

--- a/include/nene/math/rect.h
+++ b/include/nene/math/rect.h
@@ -9,7 +9,7 @@ SPDX-License-Identifier: Zlib
 #define NENE_RECT_H
 
 #include <stdbool.h>
-#include <SDL.h>
+#include "SDL.h"
 
 #include "nene/math/vec2i.h"
 

--- a/include/nene/math/rectf.h
+++ b/include/nene/math/rectf.h
@@ -9,7 +9,7 @@ SPDX-License-Identifier: Zlib
 #define NENE_RECTF_H
 
 #include <stdbool.h>
-#include <SDL.h>
+#include "SDL.h"
 
 #include "nene/math/vec2.h"
 #include "nene/math/rect.h"

--- a/include/nene/texture.h
+++ b/include/nene/texture.h
@@ -10,7 +10,7 @@ SPDX-License-Identifier: Zlib
 
 #include <stdint.h>
 #include <stdbool.h>
-#include <SDL.h>
+#include "SDL.h"
 
 #include "nene/math/vec2.h"
 #include "nene/math/rect.h"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,7 +3,32 @@
 # Please refer to the LICENSE file for details
 # SPDX-License-Identifier: Zlib
 
-target_sources(nene PUBLIC
+# variables
+set(NENE_PROJECT_DIR "${PROJECT_SOURCE_DIR}")
+set(NENE_INCLUDE_DIR "${NENE_PROJECT_DIR}/include")
+
+add_library(nene STATIC)
+add_library(nene::nene ALIAS nene)
+
+# set the C standard, be sure to follow what's written on compile_flags.txt file.
+# NOTE: if you change this, be sure to update the same setting examples/c/CMakeLists.txt
+set_target_properties(nene PROPERTIES
+  C_STANDARD 99
+  C_STANDARD_REQUIRED YES
+  C_EXTENSIONS NO
+)
+
+# add the nene include directory
+target_include_directories(nene PUBLIC "${PROJECT_SOURCE_DIR}/include")
+
+# add the sdl include directories (TODO: remove these once the (game) usage of SDL get's unnecessary)
+target_include_directories(nene PUBLIC "${PROJECT_SOURCE_DIR}/external/SDL/include")
+target_include_directories(nene PUBLIC "${PROJECT_SOURCE_DIR}/external/SDL_mixer/include")
+target_include_directories(nene PUBLIC "${PROJECT_SOURCE_DIR}/external/SDL_image")
+target_include_directories(nene PUBLIC "${PROJECT_SOURCE_DIR}/external/SDL_ttf")
+
+# set the sources of the nene target
+set(NENE_SOURCE_FILES
   core.c
   texture.c
   font.c
@@ -24,14 +49,38 @@ target_sources(nene PUBLIC
   color.c
 )
 
-# # add the nene include directory
-target_include_directories(nene PUBLIC ${PROJECT_SOURCE_DIR}/include)
+# set the headers of the nene target
+set(NENE_HEADER_FILES
+  "${NENE_INCLUDE_DIR}/nene/core.h"
+  "${NENE_INCLUDE_DIR}/nene/config.h"
+  "${NENE_INCLUDE_DIR}/nene/texture.h"
+  "${NENE_INCLUDE_DIR}/nene/font.h"
+  "${NENE_INCLUDE_DIR}/nene/texture_atlas.h"
+  "${NENE_INCLUDE_DIR}/nene/audio/music.h"
+  "${NENE_INCLUDE_DIR}/nene/audio/sound.h"
+  "${NENE_INCLUDE_DIR}/nene/math/vec2i.h"
+  "${NENE_INCLUDE_DIR}/nene/math/vec2.h"
+  "${NENE_INCLUDE_DIR}/nene/math/rect.h"
+  "${NENE_INCLUDE_DIR}/nene/math/rectf.h"
+  "${NENE_INCLUDE_DIR}/nene/math/grid.h"
+  "${NENE_INCLUDE_DIR}/nene/math/segment.h"
+  "${NENE_INCLUDE_DIR}/nene/math/shape.h"
+  "${NENE_INCLUDE_DIR}/nene/intersections.h"
+  "${NENE_INCLUDE_DIR}/nene/collision.h"
+  "${NENE_INCLUDE_DIR}/nene/animation.h"
+  "${NENE_INCLUDE_DIR}/nene/tilemap.h"
+  "${NENE_INCLUDE_DIR}/nene/color.h"
+)
 
-# # add the sdl include directories (NOTE: remove these once the (game) usage of SDL get's unnecessary)
-target_include_directories(nene PUBLIC ${PROJECT_SOURCE_DIR}/external/SDL/include)
-target_include_directories(nene PUBLIC ${PROJECT_SOURCE_DIR}/external/SDL_mixer/include)
-target_include_directories(nene PUBLIC ${PROJECT_SOURCE_DIR}/external/SDL_image)
-target_include_directories(nene PUBLIC ${PROJECT_SOURCE_DIR}/external/SDL_ttf)
+# set the sources and the headers as the nene target sources
+target_sources(nene PUBLIC ${NENE_SOURCE_FILES})
+
+# header files added, that's also necessary to install the header files
+# for development
+target_sources(nene PUBLIC FILE_SET HEADERS
+  BASE_DIRS "${NENE_INCLUDE_DIR}"
+  FILES ${NENE_HEADER_FILES}
+)
 
 # add linking to the external dependencies (SDL libraries) to the target
 target_link_libraries(nene PUBLIC external_libs)

--- a/src/audio/music.c
+++ b/src/audio/music.c
@@ -6,7 +6,7 @@ SPDX-License-Identifier: Zlib
 */
 
 #include "nene/audio/music.h"
-#include <SDL.h>
+#include "SDL.h"
 
 Mix_Music *nene_Music_get_raw(nene_Music music) {
   SDL_assert(music.raw != NULL);

--- a/src/audio/sound.c
+++ b/src/audio/sound.c
@@ -6,7 +6,7 @@ SPDX-License-Identifier: Zlib
 */
 
 #include "nene/audio/sound.h"
-#include <SDL.h>
+#include "SDL.h"
 
 Mix_Chunk *nene_Sound_get_raw(nene_Sound sound) {
   SDL_assert(sound.raw != NULL);

--- a/src/core.c
+++ b/src/core.c
@@ -6,12 +6,12 @@ SPDX-License-Identifier: Zlib
 */
 
 #include <math.h>
-#include <SDL_events.h>
-#include <SDL_image.h>
-#include <SDL_ttf.h>
-#include <SDL_mixer.h>
-#include "nene/core.h"
 #include <stdio.h>
+#include "SDL_events.h"
+#include "SDL_image.h"
+#include "SDL_ttf.h"
+#include "SDL_mixer.h"
+#include "nene/core.h"
 
 // define and empty-initialize global variables
 nene_Core _nene_instance = { .quit = false };

--- a/src/font.c
+++ b/src/font.c
@@ -5,7 +5,7 @@ Please refer to the LICENSE file for details
 SPDX-License-Identifier: Zlib
 */
 
-#include <SDL.h>
+#include "SDL.h"
 #include "nene/font.h"
 #include "nene/core.h"
 

--- a/src/texture.c
+++ b/src/texture.c
@@ -5,8 +5,8 @@ Please refer to the LICENSE file for details
 SPDX-License-Identifier: Zlib
 */
 
-#include <SDL_image.h>
-#include <SDL_render.h>
+#include "SDL_image.h"
+#include "SDL_render.h"
 #include "nene/texture.h"
 #include "nene/core.h"
 


### PR DESCRIPTION
Note: this was only tested on "x64 Native Tools Command Prompt" environment on Windows, using the clang compiler, next month Linux support will be tested.

With that, Nene it's not supposed to be used as a sub-directory of a game project (unless if the developer choice to), instead, Nene should be used just as SDL2 it's generally used: having a single (at least per-version) compiled version available on the system.

With basic support to CMake install (`cmake --install`), that's easier to accomplish, for instance, all the `dll`s required to run the game are easily available on the `bin` directory of the installation directory (that is, cmake's "prefix"), while the required headers for compilation are available on the `include`, and the `nene.lib` static library on `lib` directory.

Here's a example to compile a single C source file (using clang on Windows, consider that nene was installed using `cmake --install build --prefix nene`, that is, the final output it's on the `nene` directory):

```sh
> clang -fuse-ld=lld-link -Xlinker /subsystem:windows my_source.c -I nene\include\ -I nene\include\SDL2 -lSDL2main -lSDL2 -lSDL2_image -lSDL2_mixer -lSDL2_ttf -lnene -lshell32 -L nene\lib -o my_source.exe
```

This PR is related with #36.